### PR TITLE
Update README.md to use HTTP link to clone the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ```bash
 -- Clone repo
-git clone git@github.com:fuzziebrain/docker-oracle-xe.git
+git clone https://github.com/fuzziebrain/docker-oracle-xe.git
 
 -- Set the working directory to the project folder
 cd docker-oracle-xe


### PR DESCRIPTION
Use HTTP link to clone the repo

This will allow cloning the repo without having the public key registered in GitHub.