### PR TITLE
Define CDB/PDB character set and reduce the resulting docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY ./files/${ORACLE_XE_RPM} /tmp/
 
 RUN yum install -y oracle-database-preinstall-18c && \
   yum install -y /tmp/${ORACLE_XE_RPM} && \
+  sed -i 's#CHARSET=AL32UTF8##' /etc/sysconfig/oracle-xe-18c.conf && \
   rm -rf /tmp/${ORACLE_XE_RPM}
 
 COPY ./scripts/*.sh ${ORACLE_BASE}/scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,16 @@ ENV \
   EM_REMOTE_ACCESS=enableEmRemoteAccess.sh \
   EM_RESTORE=reconfigureEm.sh \
   ORACLE_XE_RPM=oracle-database-xe-18c-1.0-1.x86_64.rpm \
+  ORACLE_PRE_RPM=oracle-database-preinstall-18c-1.0-1.el7.x86_64.rpm \
   CHECK_DB_FILE=checkDBStatus.sh
-    
-COPY ./files/${ORACLE_XE_RPM} /tmp/
 
-RUN yum install -y oracle-database-preinstall-18c && \
+RUN yum install -y wget && \
+  cd /tmp && wget --report-speed=bits https://download.oracle.com/otn-pub/otn_software/db-express/${ORACLE_XE_RPM} && \
+  curl -o /tmp/oracle-database-preinstall-18c-1.0-1.el7.x86_64.rpm https://yum.oracle.com/repo/OracleLinux/OL7/latest/x86_64/getPackage/${ORACLE_PRE_RPM} && \
+  yum install -y /tmp/${ORACLE_PRE_RPM} && \
   yum install -y /tmp/${ORACLE_XE_RPM} && \
   sed -i 's#CHARSET=AL32UTF8##' /etc/sysconfig/oracle-xe-18c.conf && \
-  rm -rf /tmp/${ORACLE_XE_RPM}
+  rm -f /tmp/*.rpm
 
 COPY ./scripts/*.sh ${ORACLE_BASE}/scripts/
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@
 
 ## Prerequisites
 
-1. [Download](https://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html) the RPM from Oracle Technology Network and save to folder. We will assume it is in `~/Downloads/oracle-database-xe-18c-1.0-1.x86_64.rpm`.
-
 1. _Optional:_ Setup docker network: `docker network create oracle_network`. This is useful if you want other containers to connect to your database (ORDS for example). You can change `oracle_network` for any name you want, however this name will be used in all the code snippets below. 
 
 1. _Optional:_ Create a folder `mkdir ~/docker/oracle-xe` which will store your Oracle XE data to be preserved after the container is destroyed.
@@ -34,9 +32,6 @@ git clone git@github.com:fuzziebrain/docker-oracle-xe.git
 
 -- Set the working directory to the project folder
 cd docker-oracle-xe
-
--- Copy the RPM to docker-odb18c-xe/files
-cp ~/Downloads/oracle-database-xe-18c-1.0-1.x86_64.rpm files/
 
 -- Build Image
 docker build -t oracle-xe:18c .
@@ -53,6 +48,7 @@ docker run -d \
   --name=oracle-xe \
   --volume ~/docker/oracle-xe:/opt/oracle/oradata \
   --network=oracle_network \
+  --env CHARSET=<used Character set>
   oracle-xe:18c
   
 # As this takes a long time to run you can keep track of the initial installation by running:
@@ -68,6 +64,7 @@ Name | Required | Description
 `--name` | Optional | Name of container. Optional but recommended
 `--volume /opt/oracle/oradata` | Optional | (recommended) If provided, data files will be stored here. If the container is destroyed can easily rebuild container using the data files.
 `--network` | Optional | If other containers need to connect to this one (ex: [ORDS](https://github.com/martindsouza/docker-ords)) then they should all be on the same docker network.
+`--env CHARSET=<value>` | Required | Define the used character set of the CDB and all PDB e.g. WE8ISO8859P1 or AL32UTF8. Skip this parameter will use standard US7ASCII character set so you can perform a "Character Set Migration" after the database is up and running (see Oracle documentation).
 `oracle-xe:18c` | Required | This is the `name:tag` of the docker image that was built in the previous step
 
 ## Container Commands


### PR DESCRIPTION
With this change you can define a different character set instead of AL32UTF8 (installation standard) of the CDB and PDBs during the "docker run"  command. Also this change will reduce the size of the resulting docker image by 2,5GB by skipping the creation of an orphan overlay. 